### PR TITLE
fix: 스티커 포스트 내 정보저장 API request 형식 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
-//	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/controller/PostStickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/controller/PostStickerController.java
@@ -1,9 +1,8 @@
 package com.justdo.glue.sticker.domain.poststicker.controller;
 
-import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerResponse;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
 import com.justdo.glue.sticker.domain.poststicker.service.PostStickerCommandServiceImpl;
 import com.justdo.glue.sticker.domain.poststicker.service.PostStickerQueryServiceImpl;
-import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse;
 import com.justdo.glue.sticker.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,31 +23,25 @@ public class PostStickerController {
     private final PostStickerQueryServiceImpl postStickerQueryService;
 
     @Operation(summary = "포스트 내 스티커 정보 저장", description = "사용자가 포스트를 업로드 할 시 스티커의 정보를 저장합니다.")
-    @Parameter(name = "postId", description = "포스트의 id, Query Parameter입니다.", required = true, example = "1", in = ParameterIn.QUERY)
-    @Parameter(name = "stickerId", description = "스티커의 id, Query Parameter입니다.", required = true, example = "1", in = ParameterIn.QUERY)
-    @Parameter(name = "xLocation", description = "스티커의 x 위치, Query Parameter입니다.", required = true, example = "1", in = ParameterIn.QUERY)
-    @Parameter(name = "yLocation", description = "스티커의 y 위치, Query Parameter입니다.", required = true, example = "1", in = ParameterIn.QUERY)
-    @Parameter(name = "width", description = "스티커의 width, Query Parameter입니다.", required = true, example = "10", in = ParameterIn.QUERY)
-    @Parameter(name = "height", description = "스티커의 height, Query Parameter입니다.", required = true, example = "10", in = ParameterIn.QUERY)
-    @Parameter(name = "angle", description = "스티커의 angle, Query Parameter입니다.", required = true, example = "0", in = ParameterIn.QUERY)
     @PostMapping("/create")
-    public ApiResponse<PostStickerResponse.PostStickerItem> savePostSticker(HttpServletRequest request,
-                                                                        @RequestParam(name = "postId") Long post_id,
-                                                                        @RequestParam(name = "stickerId") Long sticker_id,
-                                                                        @RequestParam(name = "xLocation") Double x_location,
-                                                                        @RequestParam(name = "yLocation") Double y_location,
-                                                                        @RequestParam(name = "width") Double width,
-                                                                        @RequestParam(name = "height") Double height,
-                                                                        @RequestParam(name = "angle") Double angle) {
+    public ApiResponse<PostStickerDTO.PostStickerItem> savePostSticker(@RequestBody PostStickerDTO.PostStickerItem postStickerRequest) {
+        Long postId = postStickerRequest.getPostId();
+        Long stickerId = postStickerRequest.getStickerId();
+        Double xLocation = postStickerRequest.getXLocation();
+        Double yLocation = postStickerRequest.getYLocation();
+        Double width = postStickerRequest.getWidth();
+        Double height = postStickerRequest.getHeight();
+        Double angle = postStickerRequest.getAngle();
 
-        return ApiResponse.onSuccess(postStickerCommandService.BuildPostSticker(post_id, sticker_id, x_location, y_location, width, height, angle));
+        return ApiResponse.onSuccess(postStickerCommandService.BuildPostSticker(postId, stickerId, xLocation, yLocation, width, height, angle));
     }
 
+
     @Operation(summary = "포스트 내 스티커 이미지 조회", description = "사용자가 업로드한 포스트의 스티커를 조회합니다.")
-    @Parameter(name = "postStickerId", description = "포스트 내 저장된 스티커 정보 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    @Parameter(name = "postStickerId", description = "포스트 내 저장된 개별 스티커 정보 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
     @GetMapping("/{poststickerId}")
-    public ApiResponse<PostStickerResponse.PostStickerItem> getSticker(HttpServletRequest request,
-                                                               @PathVariable(name = "poststickerId") Long poststickerId) {
+    public ApiResponse<PostStickerDTO.PostStickerItem> getSticker(HttpServletRequest request,
+                                                                  @PathVariable(name = "poststickerId") Long poststickerId) {
 
         return ApiResponse.onSuccess(postStickerQueryService.getPostStickerById(poststickerId));
     }
@@ -58,9 +51,9 @@ public class PostStickerController {
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", required = true, example = "0", in = ParameterIn.QUERY)
     @Parameter(name = "size", description = "페이지 크기, Query Parameter입니다.", required = true, example = "10", in = ParameterIn.QUERY)
     @GetMapping("/list")
-    public ApiResponse<Page<PostStickerResponse.PostStickerItem>> getStickersByPostId(@RequestParam(name = "postId") Long postId,
-                                                                                      @RequestParam(name = "page") int page,
-                                                                                      @RequestParam(name = "size") int size) {
+    public ApiResponse<Page<PostStickerDTO.PostStickerItem>> getStickersByPostId(@RequestParam(name = "postId") Long postId,
+                                                                                 @RequestParam(name = "page") int page,
+                                                                                 @RequestParam(name = "size") int size) {
         return ApiResponse.onSuccess(postStickerQueryService.getPostStickersByPostId(postId, page, size));
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
@@ -1,44 +1,52 @@
 package com.justdo.glue.sticker.domain.poststicker.dto;
 
-import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-public class PostStickerResponse {
+public class PostStickerDTO {
     @Schema(description = "스티커 포스트 정보 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
+    @Setter
     public static class PostStickerItem {
 
         @Schema(description = "포스트-스티커의 id")
+        @JsonProperty("postStickerId")
         private Long postStickerId;
 
         @Schema(description = "포스트의 id")
+        @JsonProperty("postId")
         private Long postId;
 
         @Schema(description = "스티커의 id")
+        @JsonProperty("stickerId")
         private Long stickerId;
 
         @Schema(description = "스티커의 x_location")
+        @JsonProperty("xLocation")
         private Double xLocation;
 
         @Schema(description = "스티커의 y_location")
+        @JsonProperty("yLocation")
         private Double yLocation;
 
         @Schema(description = "스티커의 width")
+        @JsonProperty("width")
         private Double width;
 
         @Schema(description = "스티커의 height")
+        @JsonProperty("height")
         private Double height;
 
         @Schema(description = "스티커의 angle")
+        @JsonProperty("angle")
         private Double angle;
     }
 
-    public static PostStickerResponse.PostStickerItem toPostStickerItem(Long postStickerId, Long stickerId, Long postId, Double xLocation, Double yLocation, Double width, Double height, Double angle) {
-
+    public static PostStickerDTO.PostStickerItem toPostStickerItem(Long postStickerId, Long stickerId, Long postId, Double xLocation, Double yLocation, Double width, Double height, Double angle) {
         return PostStickerItem.builder()
                 .postStickerId(postStickerId)
                 .postId(postId)

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandService.java
@@ -1,9 +1,7 @@
 package com.justdo.glue.sticker.domain.poststicker.service;
 
-import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerResponse;
-import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse;
-import org.springframework.web.bind.annotation.RequestParam;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
 
 public interface PostStickerCommandService {
-    PostStickerResponse.PostStickerItem BuildPostSticker(Long post_id, Long sticker_id, Double x_location, Double y_location, Double width, Double height, Double angle);
+    PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, Double xLocation, Double yLocation, Double width, Double height, Double angle);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandServiceImpl.java
@@ -1,14 +1,11 @@
 package com.justdo.glue.sticker.domain.poststicker.service;
 
 import com.justdo.glue.sticker.domain.poststicker.PostSticker;
-import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerResponse;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
 import com.justdo.glue.sticker.domain.poststicker.repository.PostStickerRepository;
-import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.toStickerItem;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +14,7 @@ public class PostStickerCommandServiceImpl implements PostStickerCommandService{
     private final PostStickerRepository postStickerRepository;
     private final PostStickerQueryServiceImpl postStickerQueryService;
     @Override
-    public PostStickerResponse.PostStickerItem BuildPostSticker(Long postId, Long stickerId, Double xLocation, Double yLocation, Double width, Double height, Double angle) {
+    public PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, Double xLocation, Double yLocation, Double width, Double height, Double angle) {
         PostSticker newPostSticker = PostSticker.builder()
                 .postId(postId)
                 .stickerId(stickerId)
@@ -28,7 +25,7 @@ public class PostStickerCommandServiceImpl implements PostStickerCommandService{
                 .angle(angle)
                 .build();
 
-        PostStickerResponse.PostStickerItem savedPostSticker = postStickerQueryService.savePostSticker(newPostSticker);
-        return PostStickerResponse.toPostStickerItem(savedPostSticker.getPostStickerId(), savedPostSticker.getPostId(), savedPostSticker.getStickerId(), savedPostSticker.getXLocation(), savedPostSticker.getYLocation(), savedPostSticker.getWidth(), savedPostSticker.getHeight(), savedPostSticker.getAngle());
+        PostStickerDTO.PostStickerItem savedPostSticker = postStickerQueryService.savePostSticker(newPostSticker);
+        return PostStickerDTO.toPostStickerItem(savedPostSticker.getPostStickerId(), savedPostSticker.getPostId(), savedPostSticker.getStickerId(), savedPostSticker.getXLocation(), savedPostSticker.getYLocation(), savedPostSticker.getWidth(), savedPostSticker.getHeight(), savedPostSticker.getAngle());
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryService.java
@@ -1,11 +1,11 @@
 package com.justdo.glue.sticker.domain.poststicker.service;
 
 import com.justdo.glue.sticker.domain.poststicker.PostSticker;
-import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerResponse;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
 import org.springframework.data.domain.Page;
 
 public interface PostStickerQueryService {
-    PostStickerResponse.PostStickerItem getPostStickerById(Long id);
-    PostStickerResponse.PostStickerItem savePostSticker(PostSticker postSticker);
-    Page<PostStickerResponse.PostStickerItem> getPostStickersByPostId(Long postId, int page, int size);
+    PostStickerDTO.PostStickerItem getPostStickerById(Long id);
+    PostStickerDTO.PostStickerItem savePostSticker(PostSticker postSticker);
+    Page<PostStickerDTO.PostStickerItem> getPostStickersByPostId(Long postId, int page, int size);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryServiceImpl.java
@@ -1,7 +1,7 @@
 package com.justdo.glue.sticker.domain.poststicker.service;
 
 import com.justdo.glue.sticker.domain.poststicker.PostSticker;
-import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerResponse;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
 import com.justdo.glue.sticker.domain.poststicker.repository.PostStickerRepository;
 import com.justdo.glue.sticker.global.exception.ApiException;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.justdo.glue.sticker.domain.poststicker.dto.PostStickerResponse.toPostStickerItem;
-import static com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.toStickerItem;
+import static com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.toPostStickerItem;
 import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus.*;
 
 @Service
@@ -28,7 +27,7 @@ public class PostStickerQueryServiceImpl implements PostStickerQueryService{
     private final PostStickerRepository postStickerRepository;
 
     @Override
-    public PostStickerResponse.PostStickerItem getPostStickerById(Long id) {
+    public PostStickerDTO.PostStickerItem getPostStickerById(Long id) {
         PostSticker postSticker = postStickerRepository.findById(id)
                 .orElseThrow(() -> new ApiException(_STICKER_POST_NOT_FOUND));
 
@@ -37,15 +36,15 @@ public class PostStickerQueryServiceImpl implements PostStickerQueryService{
 
     @Override
     @Transactional
-    public PostStickerResponse.PostStickerItem savePostSticker(PostSticker postSticker) {
+    public PostStickerDTO.PostStickerItem savePostSticker(PostSticker postSticker) {
         PostSticker savedPostSticker = Optional.ofNullable(postStickerRepository.save(postSticker))
                 .orElseThrow(() -> new ApiException(_STICKER_POST_NOT_SAVED));
 
-        return toPostStickerItem(postSticker.getId(), postSticker.getPostId(), postSticker.getStickerId(), postSticker.getXLocation(), postSticker.getYLocation(), postSticker.getWidth(), postSticker.getHeight(), postSticker.getAngle());
+        return toPostStickerItem(savedPostSticker.getId(), savedPostSticker.getPostId(), savedPostSticker.getStickerId(), savedPostSticker.getXLocation(), savedPostSticker.getYLocation(), savedPostSticker.getWidth(), savedPostSticker.getHeight(), savedPostSticker.getAngle());
     }
 
     @Override
-    public Page<PostStickerResponse.PostStickerItem> getPostStickersByPostId(Long postId, int page, int size) {
+    public Page<PostStickerDTO.PostStickerItem> getPostStickersByPostId(Long postId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<PostSticker> postStickerPage = postStickerRepository.findByPostId(postId, pageable);
 
@@ -53,7 +52,7 @@ public class PostStickerQueryServiceImpl implements PostStickerQueryService{
             throw new ApiException(_STICKER_POST_NOT_FOUND);
         }
 
-        List<PostStickerResponse.PostStickerItem> postStickerItems = postStickerPage.stream()
+        List<PostStickerDTO.PostStickerItem> postStickerItems = postStickerPage.stream()
                 .map(postSticker -> toPostStickerItem(postSticker.getId(), postSticker.getPostId(), postSticker.getStickerId(), postSticker.getXLocation(), postSticker.getYLocation(), postSticker.getWidth(), postSticker.getHeight(), postSticker.getAngle()))
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/Sticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/Sticker.java
@@ -20,7 +20,4 @@ public class Sticker extends BaseTimeEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String prompt;
-
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String style;
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/Sticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/Sticker.java
@@ -15,7 +15,7 @@ public class Sticker extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String url;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/controller/StickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/controller/StickerController.java
@@ -26,13 +26,11 @@ public class StickerController {
     //TODO: 사진 생성 횟수 초과시 막는 로직 필요
     @Operation(summary = "이미지 생성 요청", description = "사용자의 요청에 따라 이미지를 생성합니다.")
     @Parameter(name = "prompt", description = "이미지 생성에 사용될 키워드, Query Parameter입니다.", required = true, example = "cat", in = ParameterIn.QUERY)
-    @Parameter(name = "style", description = "이미지 스타일, Query Parameter입니다.", required = false, example = "Emoticon", in = ParameterIn.QUERY)
     @PostMapping("/create")
     public ApiResponse<StickerItem> createImage(HttpServletRequest request,
-                                                @RequestParam(name = "prompt") String prompt,
-                                                @RequestParam(name = "style", required = false) String style) {
+                                                @RequestParam(name = "prompt") String prompt) {
 
-        return ApiResponse.onSuccess(stickerCommandServiceImpl.generateAndSaveSticker(prompt, style));
+        return ApiResponse.onSuccess(stickerCommandServiceImpl.generateAndSaveSticker(prompt));
     }
 
     @Operation(summary = "스티커 이미지 조회", description = "사용자가 생성한 스티커를 조회합니다.")
@@ -42,5 +40,13 @@ public class StickerController {
                                                @PathVariable(name = "stickerId") Long stickerId) {
 
         return ApiResponse.onSuccess(stickerQueryServiceImpl.getStickerById(stickerId));
+    }
+
+    @Operation(summary = "스티커 이미지 삭제", description = "사용자가 생성한 스티커를 삭제합니다.")
+    @Parameter(name = "stickerId", description = "스티커 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)
+    // 스티커 삭제 요청
+    @DeleteMapping("/{stickerId}")
+    public ApiResponse<String> deleteSticker(@PathVariable Long stickerId) {
+        return ApiResponse.onSuccess(stickerCommandServiceImpl.deleteSticker(stickerId));
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/controller/StickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/controller/StickerController.java
@@ -32,6 +32,7 @@ public class StickerController {
 
         return ApiResponse.onSuccess(stickerCommandServiceImpl.generateAndSaveSticker(prompt));
     }
+    
 
     @Operation(summary = "스티커 이미지 조회", description = "사용자가 생성한 스티커를 조회합니다.")
     @Parameter(name = "stickerId", description = "스티커 Id, Path Variable입니다.", required = true, example = "1", in = ParameterIn.PATH)

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/dto/StickerResponse.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/dto/StickerResponse.java
@@ -18,19 +18,15 @@ public class StickerResponse {
         @Schema(description = "사용자가 작성한 프롬프트")
         private String stickerPrompt;
 
-        @Schema(description = "스티커 타입(사진 또는 스티커형식)")
-        private String stickerType;
-
         @Schema(description = "url이 아닌 base64 형태로 저장")
         private String stickerUrl;
 
     }
 
-    public static StickerGenerationResult toStickerGenerationResult(String stickerPrompt, String stickerType, String stickerUrl) {
+    public static StickerGenerationResult toStickerGenerationResult(String stickerPrompt, String stickerUrl) {
 
         return StickerGenerationResult.builder()
                 .stickerPrompt(stickerPrompt)
-                .stickerType(stickerType)
                 .stickerUrl(stickerUrl)
                 .build();
     }
@@ -49,16 +45,13 @@ public class StickerResponse {
 
         private String prompt;
 
-        private String style;
-
     }
 
-    public static StickerItem toStickerItem(Long id, String url, String prompt, String style){
+    public static StickerItem toStickerItem(Long id, String url, String prompt){
         return StickerItem.builder()
                 .stickerId(id)
                 .url(url)
                 .prompt(prompt)
-                .style(style)
                 .build();
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandService.java
@@ -2,5 +2,6 @@ package com.justdo.glue.sticker.domain.sticker.service;
 import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.*;
 
 public interface StickerCommandService {
-    StickerItem generateAndSaveSticker(String stickerPrompt, String stickerType);
+    StickerItem generateAndSaveSticker(String stickerPrompt);
+    String deleteSticker(Long stickerId);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandServiceImpl.java
@@ -96,13 +96,12 @@ public class StickerCommandServiceImpl implements StickerCommandService {
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
         System.out.println(response);
 
-        if (response.statusCode() == 200) {
-            Map<String, Object> responseMap = objectMapper.readValue(response.body(), Map.class);
-            List<Map<String, String>> data = (List<Map<String, String>>) responseMap.get("data");
-            return data.get(0).get("b64_json");
-        } else {
+        if (response.statusCode() != 200)
             throw new RuntimeException("Failed to generate image: " + response.body());
-        }
+
+        Map<String, Object> responseMap = objectMapper.readValue(response.body(), Map.class);
+        List<Map<String, String>> data = (List<Map<String, String>>) responseMap.get("data");
+        return data.get(0).get("b64_json");
     }
 
     private StickerItem saveSticker(Sticker sticker) {
@@ -114,8 +113,6 @@ public class StickerCommandServiceImpl implements StickerCommandService {
     @Transactional
     public String deleteSticker(Long stickerId) {
         StickerItem sticker = stickerQueryService.getStickerById(stickerId);
-        // 권한이 부족해서 삭제가 안됨 ㅎㅎ..;
-        // s3Service.deleteImage(sticker.getUrl());
 
         Sticker deleteSticker = Sticker.builder()
                 .url(sticker.getUrl())

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandServiceImpl.java
@@ -1,56 +1,140 @@
 package com.justdo.glue.sticker.domain.sticker.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.justdo.glue.sticker.domain.sticker.Sticker;
 import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse;
 import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.StickerGenerationResult;
 import com.justdo.glue.sticker.domain.sticker.repository.StickerRepository;
+import com.justdo.glue.sticker.global.exception.ApiException;
+import com.justdo.glue.sticker.global.response.ApiResponse;
+import com.justdo.glue.sticker.global.s3.S3Service;
 import com.theokanning.openai.image.CreateImageRequest;
 import jakarta.annotation.Resource;
 import com.theokanning.openai.service.OpenAiService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import static com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.*;
+import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus._INTERNAL_SERVER_ERROR;
+import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus._STICKER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Configuration
 public class StickerCommandServiceImpl implements StickerCommandService {
+    @Value("${api-key}")
+    private String OPENAI_API_KEY;
+
     @Resource(name = "getOpenAiService")
     private final OpenAiService openAiService;
+    private final StickerQueryService stickerQueryService;
+    private final S3Service s3Service;
     private final StickerRepository stickerRepository;
-    private final StickerQueryServiceImpl stickerQueryServiceImpl;
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/images/generations";
 
-    //TODO: 생성한 스티커 저장 로직 제대로 구현 안됨
     @Override
-    public StickerItem generateAndSaveSticker(String stickerPrompt, String stickerType) {
-        StickerGenerationResult generatedResult = generation(stickerPrompt, stickerType);
+    public StickerItem generateAndSaveSticker(String stickerPrompt) {
+        StickerGenerationResult generatedResult = generation(stickerPrompt);
 
         Sticker newSticker = Sticker.builder()
                 .url(generatedResult.getStickerUrl())
                 .prompt(generatedResult.getStickerPrompt())
-                .style(generatedResult.getStickerType())
                 .build();
 
         return saveSticker(newSticker);
     }
 
-    private StickerGenerationResult generation(String stickerPrompt, String stickerType) {
-        CreateImageRequest createImageRequest = CreateImageRequest.builder()
-                .prompt(stickerPrompt)
-                .size("512x512")
-                .n(1)
-                .responseFormat("b64_json")
+    // DALL-E API를 통해 이미지를 생성하고 S3에 업로드 후 URL 반환
+    private StickerGenerationResult generation(String stickerPrompt) {
+
+        stickerPrompt = "애플 이모티콘 스타일로" + stickerPrompt + "에 해당하는 이모티콘을 귀엽게 만들어줘.";
+
+        try {
+            String b64Image = generateImage(stickerPrompt);
+            String s3Url = s3Service.uploadBase64Image(b64Image, "generated-sticker.png");
+            return toStickerGenerationResult(stickerPrompt, s3Url);
+        } catch (Exception e) {
+            throw new ApiException(_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // OpenAI API를 호출하여 이미지를 생성하는 메서드
+    private String generateImage(String prompt) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String requestBody = objectMapper.writeValueAsString(Map.of(
+                "prompt", prompt,
+                "model", "dall-e-3",
+                "n", 1,
+                "response_format", "b64_json",
+                "size", "1024x1024"
+        ));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(OPENAI_API_URL))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + OPENAI_API_KEY)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                 .build();
 
-        String b64 = openAiService.createImage(createImageRequest).getData().get(0).getB64Json();
-        return StickerResponse.toStickerGenerationResult(stickerPrompt, stickerType, b64);
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        System.out.println(response);
+
+        if (response.statusCode() == 200) {
+            Map<String, Object> responseMap = objectMapper.readValue(response.body(), Map.class);
+            List<Map<String, String>> data = (List<Map<String, String>>) responseMap.get("data");
+            return data.get(0).get("b64_json");
+        } else {
+            throw new RuntimeException("Failed to generate image: " + response.body());
+        }
     }
+//    private StickerGenerationResult generation(String stickerPrompt) {
+////        stickerPrompt = "애플 이모티콘 스타일로" + stickerPrompt + "에 해당하는 이모티콘을 귀엽게 만들어줘.";
+////        CreateImageRequest createImageRequest = CreateImageRequest.builder()
+////                .prompt(stickerPrompt)
+////                //.model("dall-e-3")
+////                .size("1024x1024")
+////                .n(1)
+////                .responseFormat("b64_json")
+////                .build();
+////
+////        String b64 = openAiService.createImage(createImageRequest).getData().get(0).getB64Json();
+////        String s3Url = s3Service.uploadBase64Image(b64, "generated-sticker.png");
+////
+////        return StickerResponse.toStickerGenerationResult(stickerPrompt, s3Url);
+//    }
 
     private StickerItem saveSticker(Sticker sticker) {
-        StickerItem savedSticker = stickerQueryServiceImpl.saveSticker(sticker);
-        return toStickerItem(savedSticker.getStickerId(), savedSticker.getUrl(), savedSticker.getPrompt(), savedSticker.getStyle());
+        StickerItem savedSticker = stickerQueryService.saveSticker(sticker);
+        return toStickerItem(savedSticker.getStickerId(), savedSticker.getUrl(), savedSticker.getPrompt());
     }
 
+    // 스티커와 관련된 이미지 삭제
+    @Transactional
+    public String deleteSticker(Long stickerId) {
+        StickerItem sticker = stickerQueryService.getStickerById(stickerId);
+        // 권한이 부족해서 삭제가 안됨 ㅎㅎ..;
+        // s3Service.deleteImage(sticker.getUrl());
+
+        Sticker deleteSticker = Sticker.builder()
+                .url(sticker.getUrl())
+                .prompt(sticker.getPrompt())
+                .build();
+
+        stickerQueryService.deleteSticker(deleteSticker);
+        return "스티커가 성공적으로 삭제되었습니다.";
+    }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerCommandServiceImpl.java
@@ -59,7 +59,10 @@ public class StickerCommandServiceImpl implements StickerCommandService {
     // DALL-E API를 통해 이미지를 생성하고 S3에 업로드 후 URL 반환
     private StickerGenerationResult generation(String stickerPrompt) {
 
-        stickerPrompt = "애플 이모티콘 스타일로" + stickerPrompt + "에 해당하는 이모티콘을 귀엽게 만들어줘.";
+        stickerPrompt = "Create an emoji in the style of Apple's emojis, themed around '" + stickerPrompt +
+                "'. The emoji should be cute, illustrated (not realistic), and without thick outlines. " +
+                "It is crucial that the entire background of the emoji, excluding the emoji itself, is plain white. " +
+                "Design the emoji with a 1:1 aspect ratio.";
 
         try {
             String b64Image = generateImage(stickerPrompt);
@@ -101,21 +104,6 @@ public class StickerCommandServiceImpl implements StickerCommandService {
             throw new RuntimeException("Failed to generate image: " + response.body());
         }
     }
-//    private StickerGenerationResult generation(String stickerPrompt) {
-////        stickerPrompt = "애플 이모티콘 스타일로" + stickerPrompt + "에 해당하는 이모티콘을 귀엽게 만들어줘.";
-////        CreateImageRequest createImageRequest = CreateImageRequest.builder()
-////                .prompt(stickerPrompt)
-////                //.model("dall-e-3")
-////                .size("1024x1024")
-////                .n(1)
-////                .responseFormat("b64_json")
-////                .build();
-////
-////        String b64 = openAiService.createImage(createImageRequest).getData().get(0).getB64Json();
-////        String s3Url = s3Service.uploadBase64Image(b64, "generated-sticker.png");
-////
-////        return StickerResponse.toStickerGenerationResult(stickerPrompt, s3Url);
-//    }
 
     private StickerItem saveSticker(Sticker sticker) {
         StickerItem savedSticker = stickerQueryService.saveSticker(sticker);

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerQueryService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerQueryService.java
@@ -7,4 +7,5 @@ import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.StickerItem;
 public interface StickerQueryService {
     StickerItem getStickerById(Long id);
     StickerItem saveSticker(Sticker sticker);
+    void deleteSticker(Sticker sticker);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerQueryServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/service/StickerQueryServiceImpl.java
@@ -10,8 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 import static com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.*;
-import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus._STICKER_NOT_FOUND;
-import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus._STICKER_NOT_SAVED;
+import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus.*;
 
 
 @Service
@@ -26,7 +25,7 @@ public class StickerQueryServiceImpl implements StickerQueryService {
         Sticker sticker = stickerRepository.findById(id)
                 .orElseThrow(() -> new ApiException(_STICKER_NOT_FOUND));
 
-        return toStickerItem(sticker.getId(), sticker.getUrl(), sticker.getPrompt(), sticker.getStyle());
+        return toStickerItem(sticker.getId(), sticker.getUrl(), sticker.getPrompt());
     }
 
     @Override
@@ -35,6 +34,15 @@ public class StickerQueryServiceImpl implements StickerQueryService {
         Sticker savedSticker = Optional.ofNullable(stickerRepository.save(sticker))
                 .orElseThrow(() -> new ApiException(_STICKER_NOT_SAVED));
 
-        return toStickerItem(savedSticker.getId(), savedSticker.getUrl(), sticker.getPrompt(), sticker.getStyle());
+        return toStickerItem(savedSticker.getId(), savedSticker.getUrl(), sticker.getPrompt());
+    }
+
+    @Transactional
+    public void deleteSticker(Sticker sticker) {
+        try {
+            stickerRepository.delete(sticker);
+        } catch (Exception e) {
+            throw new ApiException(_STICKER_NOT_DELETED);
+        }
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/global/config/ChatGPTConfig.java
+++ b/src/main/java/com/justdo/glue/sticker/global/config/ChatGPTConfig.java
@@ -1,4 +1,4 @@
-package com.justdo.glue.sticker.domain.sticker.config;
+package com.justdo.glue.sticker.global.config;
 
 import com.theokanning.openai.service.OpenAiService;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/justdo/glue/sticker/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/justdo/glue/sticker/global/response/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // Sticker 관련
     _STICKER_NOT_FOUND(HttpStatus.NOT_FOUND, "STICKER_001", "요청한 sticker는 존재하지 않습니다."),
     _STICKER_NOT_SAVED(HttpStatus.NOT_FOUND, "STICKER_002", "sticker를 서버에 저장하는 과정에서 오류가 발생했습니다."),
+    _STICKER_NOT_DELETED(HttpStatus.NOT_FOUND,"STICKER_003", "sticker가 삭제되는 과정에서 오류가 발생했습니다."),
 
     // Sticker Post 관련
     _STICKER_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "STICKER_POST_001", "요청한 포스트와 해당 포스트의 sticker는 존재하지 않습니다."),

--- a/src/main/java/com/justdo/glue/sticker/global/s3/S3Service.java
+++ b/src/main/java/com/justdo/glue/sticker/global/s3/S3Service.java
@@ -58,12 +58,12 @@ public class S3Service {
 
         try (InputStream inputStream = new ByteArrayInputStream(imageBytes)) {
             amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata));
-            // 업로드된 파일의 URL 생성
-            return getPublicUrl(fileName);
         } catch (IOException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "파일 업로드에 실패했습니다.");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
         }
+
+        // 업로드된 파일의 URL 생성
+        return getPublicUrl(fileName);
     }
 
     // 업로드된 파일의 URL 생성
@@ -80,30 +80,10 @@ public class S3Service {
     // URL에서 파일 이름 추출
     private String extractFileNameFromUrl(String url) {
         String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucket, region);
-        if (url.startsWith(prefix)) {
-            return url.substring(prefix.length());
-        } else {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 URL 형식입니다.");
-        }
-    }
 
-//    // 이미지 삭제
-//    public void deleteFile(String fileName) {
-//        try {
-//            String s3File = extractImageFromUrl(fileName);
-//            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, s3File));
-//        } catch (AmazonS3Exception e) {
-//            throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
-//        }
-//    }
-//
-//    // S3 주소에 이미지 URL 추출
-//    private String extractImageFromUrl(String imgUrl) {
-//        String bucketPrefix = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
-//        if (imgUrl.startsWith(bucketPrefix)) {
-//            return imgUrl.substring(bucketPrefix.length());
-//        } else {
-//            throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
-//        }
-//    }
+        if (!url.startsWith(prefix))
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 URL 형식입니다.");
+
+        return url.substring(prefix.length());
+    }
 }

--- a/src/main/java/com/justdo/glue/sticker/global/s3/S3Service.java
+++ b/src/main/java/com/justdo/glue/sticker/global/s3/S3Service.java
@@ -1,91 +1,92 @@
-//package com.justdo.glue.sticker.global.s3;
-//
-//import com.amazonaws.services.s3.AmazonS3Client;
-//import com.amazonaws.services.s3.model.*;
-//import com.justdo.glue.sticker.global.exception.ApiException;
-//import com.justdo.glue.sticker.global.response.code.status.ErrorStatus;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.context.annotation.PropertySource;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.stereotype.Service;
-//import org.springframework.web.multipart.MultipartFile;
-//import org.springframework.web.server.ResponseStatusException;
-//
-//import java.io.IOException;
-//import java.io.InputStream;
-//import java.util.ArrayList;
-//import java.util.List;
-//import java.util.UUID;
-//
-//@Service
-//@RequiredArgsConstructor
-//@PropertySource("classpath:application.yml")
-//public class S3Service {
-//
-//    private final AmazonS3Client amazonS3Client;
-//
-//    @Value("${cloud.aws.s3.bucket}")
-//    private String bucket;
-//
-//    @Value("${cloud.aws.region.static}")
-//    private String region;
-//
-//    // 파일 확장자 가져오기
-//    private String getFileExtension(String fileName) {
-//        try {
-//            return fileName.substring(fileName.lastIndexOf("."));
-//        } catch (StringIndexOutOfBoundsException e) {
-//            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-//                "잘못된 형식의 파일(" + fileName + ") 입니다.");
-//        }
-//    }
-//
-//    // 고유한 파일명 생성
-//    private String createFileName(String fileName) {
-//        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
-//    }
-//
-//    // 여러 개의 이미지 업로드
-//    public List<String> uploadFiles(List<MultipartFile> multipartFiles) {
-//        List<String> fileList = new ArrayList<>();
-//
-//        for (MultipartFile file : multipartFiles) {
-//            String fileName = createFileName(file.getOriginalFilename());
-//            ObjectMetadata objectMetadata = new ObjectMetadata();
-//            objectMetadata.setContentLength(file.getSize());
-//            objectMetadata.setContentType(file.getContentType());
-//
-//            try (InputStream inputStream = file.getInputStream()) {
-//                amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream,
-//                    objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
-//                fileList.add(amazonS3Client.getUrl(bucket, fileName).toString());
-//            } catch (IOException e) {
-//                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-//                    "파일 업로드에 실패했습니다.");
-//            }
-//        }
-//        return fileList;
-//    }
-//
-//    // 하나의 이미지 업로드
-//    public String uploadFile(MultipartFile file) {
-//
-//        String fileName = createFileName(file.getOriginalFilename());
-//        ObjectMetadata objectMetadata = new ObjectMetadata();
-//        objectMetadata.setContentLength(file.getSize());
-//        objectMetadata.setContentType(file.getContentType());
-//
-//        try (InputStream inputStream = file.getInputStream()) {
-//            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream,
-//                objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
-//        } catch (IOException e) {
-//            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-//                "파일 업로드에 실패했습니다.");
-//        }
-//        return amazonS3Client.getUrl(bucket, fileName).toString();
-//    }
-//
+package com.justdo.glue.sticker.global.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.*;
+import com.justdo.glue.sticker.global.exception.ApiException;
+import com.justdo.glue.sticker.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@PropertySource("classpath:application.yml")
+public class S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    // 파일 확장자 가져오기
+    private String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                "잘못된 형식의 파일(" + fileName + ") 입니다.");
+        }
+    }
+
+    // 고유한 파일명 생성
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    // Base64 인코딩된 이미지를 S3에 업로드
+    public String uploadBase64Image(String base64Image, String originalFileName) {
+        byte[] imageBytes = Base64.getDecoder().decode(base64Image);
+        String fileName = createFileName(originalFileName);
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(imageBytes.length);
+        objectMetadata.setContentType("image/png");
+
+        try (InputStream inputStream = new ByteArrayInputStream(imageBytes)) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata));
+            // 업로드된 파일의 URL 생성
+            return getPublicUrl(fileName);
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "파일 업로드에 실패했습니다.");
+        }
+    }
+
+    // 업로드된 파일의 URL 생성
+    private String getPublicUrl(String fileName) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
+    }
+
+    // 이미지 삭제
+    public void deleteImage(String imageUrl) {
+        String fileName = extractFileNameFromUrl(imageUrl);
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
+    }
+
+    // URL에서 파일 이름 추출
+    private String extractFileNameFromUrl(String url) {
+        String prefix = String.format("https://%s.s3.%s.amazonaws.com/", bucket, region);
+        if (url.startsWith(prefix)) {
+            return url.substring(prefix.length());
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 URL 형식입니다.");
+        }
+    }
+
 //    // 이미지 삭제
 //    public void deleteFile(String fileName) {
 //        try {
@@ -105,4 +106,4 @@
 //            throw new ApiException(ErrorStatus._S3_IMAGE_NOT_FOUND);
 //        }
 //    }
-//}
+}

--- a/src/main/java/com/justdo/glue/sticker/global/s3/S3config.java
+++ b/src/main/java/com/justdo/glue/sticker/global/s3/S3config.java
@@ -1,33 +1,33 @@
-//package com.justdo.glue.sticker.global.s3;
-//
-//import com.amazonaws.auth.AWSStaticCredentialsProvider;
-//import com.amazonaws.auth.BasicAWSCredentials;
-//import com.amazonaws.services.s3.AmazonS3Client;
-//import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//
-//@Configuration
-//public class S3config {
-//
-//    @Value("${cloud.aws.credentials.access-key}")
-//    private String accessKey;
-//
-//    @Value("${cloud.aws.credentials.secret-key}")
-//    private String secretKey;
-//
-//    @Value("${cloud.aws.region.static}")
-//    private String region;
-//
-//    @Bean
-//    public AmazonS3Client amazonS3Client() {
-//        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
-//
-//        return (AmazonS3Client) AmazonS3ClientBuilder
-//            .standard()
-//            .withRegion(region)
-//            .withCredentials(new AWSStaticCredentialsProvider(credentials))
-//            .build();
-//    }
-//}
+package com.justdo.glue.sticker.global.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+            .standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
+    }
+}


### PR DESCRIPTION
## 📌 요약

- 기존 query parameter에서 request body로 받는걸로 수정

## 📝 상세 내용

- 스티커 포스트 내 정보저장 API request 형식 수정
<img width="696" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/4bb243c7-1573-4d71-afe9-421a4a7b325a">

- 스티커 dall-e-3 api로 수정
<img width="805" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/85fa8b32-d84c-4e7f-b15d-82ce8c696ab8">
<img width="300" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/dc283e6f-160d-4c4c-ac91-7ecc9cbdbe8d">
꽤나 귀여워진 모습 ㅎㅎ..

- 스티커 삭제 api 추가
<img width="696" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/b82bcfc2-d9c0-40fb-9366-7d85a5309887">
