### PR TITLE
✨GLUE-327 fix: API URL, 유저 id 값 jwt 토큰값으로 받도록 변경

### DIFF
--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/controller/StickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/controller/StickerController.java
@@ -37,6 +37,7 @@ public class StickerController {
 
         Long memberId = jwtProvider.getUserIdFromToken(request);
 
+
         return ApiResponse.onSuccess(stickerCommandService.generateAndSaveSticker(prompt, memberId));
     }
 


### PR DESCRIPTION
## 📌 요약

- API URL 수정
- JWT token값 이용해 userID값 받도록 수정

## 📝 상세 내용

- 노션에 업데이트 해둘 예정

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #327
