### PR TITLE
fix: 페이징 리턴 형식 수정

### DIFF
--- a/src/main/java/com/justdo/glue/sticker/domain/basicSticker/controller/BasicStickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/basicSticker/controller/BasicStickerController.java
@@ -1,5 +1,6 @@
 package com.justdo.glue.sticker.domain.basicSticker.controller;
 
+import com.justdo.glue.sticker.domain.basicSticker.BasicSticker;
 import com.justdo.glue.sticker.domain.basicSticker.dto.BasicStickerDTO.*;
 import com.justdo.glue.sticker.domain.basicSticker.service.BasicStickerQueryService;
 import com.justdo.glue.sticker.domain.common.CustomPage;
@@ -25,13 +26,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class BasicStickerController {
     private final BasicStickerQueryService basicStickerQueryService;
 
-    @Operation(summary = "기본 스티커 이미지 페이징 조회", description =
-            "기본 스티커를 페이징 처리하여 조회합니다.")
+    @Operation(summary = "기본 스티커 이미지 페이징 조회", description = "기본 스티커를 페이징 처리하여 조회합니다.")
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", required = true, example = "0", in = ParameterIn.QUERY)
     @Parameter(name = "size", description = "페이지 크기, Query Parameter입니다.", required = true, example = "10", in = ParameterIn.QUERY)
     @GetMapping("/basics")
-    public ApiResponse<CustomPage<BasicStickerItems>> getBasicStickersPage(@RequestParam(name = "page") int page,
-                                                                           @RequestParam(name = "size") int size) {
+    public ApiResponse<CustomPage<BasicSticker, BasicStickerItems>> getBasicStickersPage(@RequestParam(name = "page") int page,
+                                                                                         @RequestParam(name = "size") int size) {
         return ApiResponse.onSuccess(basicStickerQueryService.getBasicStickersPage(page, size));
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/basicSticker/service/BasicStickerQueryService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/basicSticker/service/BasicStickerQueryService.java
@@ -1,9 +1,10 @@
 package com.justdo.glue.sticker.domain.basicSticker.service;
 
+import com.justdo.glue.sticker.domain.basicSticker.BasicSticker;
 import com.justdo.glue.sticker.domain.basicSticker.dto.BasicStickerDTO;
 import com.justdo.glue.sticker.domain.common.CustomPage;
 import org.springframework.data.domain.Page;
 
 public interface BasicStickerQueryService {
-    CustomPage<BasicStickerDTO.BasicStickerItems> getBasicStickersPage(int page, int size);
+    CustomPage<BasicSticker, BasicStickerDTO.BasicStickerItems> getBasicStickersPage(int page, int size);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/basicSticker/service/BasicStickerQueryServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/basicSticker/service/BasicStickerQueryServiceImpl.java
@@ -28,12 +28,12 @@ public class BasicStickerQueryServiceImpl implements BasicStickerQueryService {
     private final StickerQueryService StickerQueryService;
 
     @Override
-    public CustomPage<BasicStickerItems> getBasicStickersPage(int page, int size) {
+    public CustomPage<BasicSticker, BasicStickerItems> getBasicStickersPage(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<BasicSticker> basicStickerPage = basicStickerRepository.findAll(pageable);
 
         if (basicStickerPage.isEmpty()) {
-            return new CustomPage<>(Page.empty(pageable));  // 빈 페이지 반환
+            return new CustomPage<>(Page.empty(pageable), null);  // 빈 페이지 반환
         }
 
         List<Long> stickerIds = basicStickerPage.stream()
@@ -46,8 +46,6 @@ public class BasicStickerQueryServiceImpl implements BasicStickerQueryService {
 
         BasicStickerItems basicStickerItems = toBasicStickerItems(stickerItems);
 
-        List<BasicStickerItems> userStickerItemsList = List.of(basicStickerItems);
-
-        return new CustomPage<>(new PageImpl<>(userStickerItemsList, pageable, basicStickerPage.getTotalElements()));
+        return new CustomPage<>(basicStickerPage, basicStickerItems);
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/common/CustomPage.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/common/CustomPage.java
@@ -5,29 +5,29 @@ import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-public class CustomPage<T> {
-    private List<T> content;
+public class CustomPage<T, C> {
+    private C content;
     private boolean isFirst;
     private boolean isLast;
     private int totalPage;
     private long totalElements;
     private int size;
-    private int number;
+    private int currPage;
     private boolean hasNext;
 
-    public CustomPage(Page<T> page) {
-        this.content = page.getContent();
+    public CustomPage(Page<T> page, C content) {
+        this.content = content;
         this.isFirst = page.isFirst();
         this.isLast = page.isLast();
         this.totalPage = page.getTotalPages();
         this.totalElements = page.getTotalElements();
         this.size = page.getSize();
-        this.number = page.getNumber();
+        this.currPage = page.getNumber();
         this.hasNext = page.hasNext();
     }
 
     @JsonProperty("content")
-    public List<T> getContent() {
+    public C getContent() {
         return content;
     }
 
@@ -57,8 +57,8 @@ public class CustomPage<T> {
     }
 
     @JsonProperty("number")
-    public int getNumber() {
-        return number;
+    public int getCurrPage() {
+        return currPage;
     }
 
     @JsonProperty("hasNext")

--- a/src/main/java/com/justdo/glue/sticker/domain/userSticker/controller/UserStickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/userSticker/controller/UserStickerController.java
@@ -1,6 +1,8 @@
 package com.justdo.glue.sticker.domain.userSticker.controller;
 
 import com.justdo.glue.sticker.domain.common.CustomPage;
+import com.justdo.glue.sticker.domain.userSticker.UserSticker;
+import com.justdo.glue.sticker.domain.userSticker.dto.UserStickerResponse;
 import com.justdo.glue.sticker.domain.userSticker.dto.UserStickerResponse.*;
 import com.justdo.glue.sticker.domain.userSticker.service.UserStickerQueryService;
 import com.justdo.glue.sticker.global.response.ApiResponse;
@@ -40,9 +42,9 @@ public class UserStickerController {
     @Parameter(name = "page", description = "페이지 번호, Query Parameter입니다.", required = true, example = "0", in = ParameterIn.QUERY)
     @Parameter(name = "size", description = "페이지 크기, Query Parameter입니다.", required = true, example = "10", in = ParameterIn.QUERY)
     @GetMapping("/users/pages")
-    public ApiResponse<CustomPage<UserStickerItems>> getSpecificUserStickersPage(HttpServletRequest request,
-                                                                                 @RequestParam(name = "page") int page,
-                                                                                 @RequestParam(name = "size") int size) {
+    public ApiResponse<CustomPage<UserSticker, UserStickerResponse.UserStickerItems>> getSpecificUserStickersPage(HttpServletRequest request,
+                                                                                                                  @RequestParam(name = "page") int page,
+                                                                                                                  @RequestParam(name = "size") int size) {
         Long userId = jwtProvider.getUserIdFromToken(request);
         return ApiResponse.onSuccess(userStickerQueryService.getPageStickersByUserId(userId, page, size));
     }

--- a/src/main/java/com/justdo/glue/sticker/domain/userSticker/service/UserStickerQueryService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/userSticker/service/UserStickerQueryService.java
@@ -1,10 +1,11 @@
 package com.justdo.glue.sticker.domain.userSticker.service;
 
 import com.justdo.glue.sticker.domain.common.CustomPage;
+import com.justdo.glue.sticker.domain.userSticker.UserSticker;
 import com.justdo.glue.sticker.domain.userSticker.dto.UserStickerResponse;
 import org.springframework.data.domain.Page;
 
 public interface UserStickerQueryService {
     UserStickerResponse.UserStickerItems getStickersByUserId(Long userId);
-    CustomPage<UserStickerResponse.UserStickerItems> getPageStickersByUserId(Long userId, int page, int size);
+    CustomPage<UserSticker, UserStickerResponse.UserStickerItems> getPageStickersByUserId(Long userId, int page, int size);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/userSticker/service/UserStickerQueryServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/userSticker/service/UserStickerQueryServiceImpl.java
@@ -44,12 +44,12 @@ public class UserStickerQueryServiceImpl implements UserStickerQueryService {
     }
 
     @Override
-    public CustomPage<UserStickerResponse.UserStickerItems> getPageStickersByUserId(Long userId, int page, int size) {
+    public CustomPage<UserSticker, UserStickerResponse.UserStickerItems> getPageStickersByUserId(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<UserSticker> userStickerPage = userStickerRepository.findByUserId(userId, pageable);
 
         if (userStickerPage.isEmpty()) {
-            return new CustomPage<>(Page.empty(pageable));  // 빈 페이지 반환
+            return new CustomPage<>(Page.empty(pageable), null);  // 빈 페이지 반환
         }
 
         List<Long> stickerIds = userStickerPage.stream()
@@ -62,8 +62,6 @@ public class UserStickerQueryServiceImpl implements UserStickerQueryService {
 
         UserStickerResponse.UserStickerItems userStickerItems = UserStickerResponse.toUserStickerItems(userId, stickerItems);
 
-        List<UserStickerResponse.UserStickerItems> userStickerItemsList = List.of(userStickerItems);
-
-        return new CustomPage<>(new PageImpl<>(userStickerItemsList, pageable, userStickerPage.getTotalElements()));
+        return new CustomPage<>(userStickerPage, userStickerItems);
     }
 }


### PR DESCRIPTION
## 📌 요약

- 페이징 API 리턴 형식 중, content가 불필요한 리스트 형식을 리턴하는 것을 확인
- content는 싱글 벨류만을 리턴하도록 형식을 변경함.

## 📝 상세 내용

- basic sticker 페이징 리스폰스 형식 변경
<img width="820" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/8f0c2034-1632-47fd-8a47-41d7e389bf91">

- 유저가 제작한 스티커 페이징 리스폰스 형식 또한 basic sticker와 동일하게 변경
<img width="800" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/0a03290c-746e-4842-88f7-63e4f2bc1c9a">

- 현재페이지에 관한 JSON 변수명 number에서 currPage로 수정
<img width="151" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/82342618-c14f-4576-bd7e-d0666cd780cd">


## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #365
