### PR TITLE
✨feat: 포스트 저장 시, 스티커 리스트형태로 저장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ application-SECRET-KEY.yml
 /.gradle
 
 application.yml
+.gradle/8.6/executionHistory/executionHistory.lock
+.gradle/8.6/fileHashes/fileHashes.bin
+.gradle/8.6/fileHashes/fileHashes.lock
+.gradle/buildOutputCleanup/buildOutputCleanup.lock

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
@@ -27,12 +27,12 @@ public class PostSticker extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "INT")
     private int yLocation;
 
-    @Column(nullable = false, columnDefinition = "INT")
-    private int width;
+    @Column(nullable = false, columnDefinition = "DOUBLE")
+    private double width;
 
-    @Column(nullable = false, columnDefinition = "INT")
-    private int height;
+    @Column(nullable = false, columnDefinition = "DOUBLE")
+    private double height;
 
-    @Column(nullable = false, columnDefinition = "INT")
-    private int angle;
+    @Column(nullable = false, columnDefinition = "DOUBLE")
+    private double angle;
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/controller/PostStickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/controller/PostStickerController.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Tag(name = "Post-Sticker API")
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +24,8 @@ public class PostStickerController {
     private final PostStickerCommandServiceImpl postStickerCommandService;
     private final PostStickerQueryServiceImpl postStickerQueryService;
 
-    @Operation(summary = "포스트 내 스티커 정보 저장", description =
-            "사용자가 포스트를 업로드 할 시 스티커의 정보를 저장합니다." +
+    @Operation(summary = "포스트 내 스티커 개별 정보 저장 - 스티커를 한개씩 저장할 때 사용합니다.", description =
+            "사용자가 포스트를 업로드 할 시 스티커의 정보를 저장합니다.\n" +
                     "업로드 된 포스트 내 스티커의 위치정보, 크기, 각도 정보를 저장하기 위해 사용합니다.")
     @PostMapping("/post")
     public ApiResponse<PostStickerDTO.PostStickerItem> savePostSticker(@RequestBody PostStickerDTO.PostStickerItem postStickerRequest) {
@@ -30,12 +33,35 @@ public class PostStickerController {
         Long stickerId = postStickerRequest.getStickerId();
         int xLocation = postStickerRequest.getXLocation();
         int yLocation = postStickerRequest.getYLocation();
-        int width = postStickerRequest.getWidth();
-        int height = postStickerRequest.getHeight();
-        int angle = postStickerRequest.getAngle();
+        double scaleX = postStickerRequest.getScaleX();
+        double scaleY = postStickerRequest.getScaleY();
+        double rotation = postStickerRequest.getRotation();
 
-        return ApiResponse.onSuccess(postStickerCommandService.BuildPostSticker(postId, stickerId, xLocation, yLocation, width, height, angle));
+        return ApiResponse.onSuccess(postStickerCommandService.BuildPostSticker(postId, stickerId, xLocation, yLocation, scaleX, scaleY, rotation));
     }
+
+    @Operation(summary = "포스트 내 스티커 전체 정보 저장 - Open Feign을 통해 post에서 사용되는 API입니다.", description =
+            "사용자가 포스트를 업로드 할 시 스티커의 모든 정보를 저장합니다.\n" +
+                    "업로드 된 포스트 내 스티커의 위치정보, 크기, 각도 정보를 저장하기 위해 사용합니다.")
+    @PostMapping("/post-list")
+    public ApiResponse<List<PostStickerDTO.PostStickerItem>> savePostStickers(@RequestBody List<PostStickerDTO.PostStickerItem> postStickerRequest) {
+
+        List<PostStickerDTO.PostStickerItem> savedItems = postStickerRequest.stream().map(item -> {
+            Long stickerId = item.getStickerId();
+            Long postId = item.getPostId();
+            int xLocation = item.getXLocation();
+            int yLocation = item.getYLocation();
+            double scaleX = item.getScaleX();
+            double scaleY = item.getScaleY();
+            double rotation = item.getRotation();
+
+            return postStickerCommandService.BuildPostSticker(postId, stickerId, xLocation, yLocation, scaleX, scaleY, rotation);
+        }).collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(savedItems);
+    }
+
+
 
     @Operation(summary = "포스트 첨부 스티커 이미지 조회 - Open Feign을 통해 post에서 사용되는 API입니다.", description =
             "사용자가 업로드한 포스트의 내부에 첨부된 스티커를 전체 조회합니다.\n" +

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
@@ -36,29 +36,29 @@ public class PostStickerDTO {
         @JsonProperty("yLocation")
         private int yLocation;
 
-        @Schema(description = "스티커의 width")
-        @JsonProperty("width")
-        private int width;
+        @Schema(description = "스티커의 scaleX")
+        @JsonProperty("scaleX")
+        private double scaleX;
 
-        @Schema(description = "스티커의 height")
-        @JsonProperty("height")
-        private int height;
+        @Schema(description = "스티커의 scaleY")
+        @JsonProperty("scaleY")
+        private double scaleY;
 
-        @Schema(description = "스티커의 angle")
-        @JsonProperty("angle")
-        private int angle;
+        @Schema(description = "스티커의 rotation")
+        @JsonProperty("rotation")
+        private double rotation;
     }
 
-    public static PostStickerDTO.PostStickerItem toPostStickerItem(Long postStickerId, Long stickerId, Long postId, int xLocation, int yLocation, int width, int height, int angle) {
+    public static PostStickerDTO.PostStickerItem toPostStickerItem(Long postStickerId, Long stickerId, Long postId, int xLocation, int yLocation, double scaleX, double scaleY, double rotation) {
         return PostStickerItem.builder()
                 .postStickerId(postStickerId)
                 .postId(postId)
                 .stickerId(stickerId)
                 .xLocation(xLocation)
                 .yLocation(yLocation)
-                .width(width)
-                .height(height)
-                .angle(angle)
+                .scaleX(scaleX)
+                .scaleY(scaleY)
+                .rotation(rotation)
                 .build();
     }
 
@@ -69,13 +69,11 @@ public class PostStickerDTO {
     @Getter
     @Setter
     public static class PostStickerItems{
-        private Long postId;
         private List<PostStickerItem> postStickerItems;
     }
 
-    public static PostStickerDTO.PostStickerItems toPostStickerItems(Long postId, List<PostStickerItem> postStickerItems){
+    public static PostStickerDTO.PostStickerItems toPostStickerItems(List<PostStickerItem> postStickerItems){
         return PostStickerItems.builder()
-                .postId(postId)
                 .postStickerItems(postStickerItems)
                 .build();
     }
@@ -111,7 +109,7 @@ public class PostStickerDTO {
     public static class PostStickerUrlItems {
 
         @Schema(description = "url포함 포스트-스티커 리스트")
-        @JsonProperty("postStickerId")
+        @JsonProperty("postStickerUrlItems")
         private List<PostStickerUrlItem> postStickerUrlItems;
     }
 

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandService.java
@@ -3,5 +3,5 @@ package com.justdo.glue.sticker.domain.poststicker.service;
 import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
 
 public interface PostStickerCommandService {
-    PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, int xLocation, int yLocation, int width, int height, int angle);
+    PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, int xLocation, int yLocation, double scaleX, double scaleY, double rotation);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandServiceImpl.java
@@ -14,18 +14,18 @@ public class PostStickerCommandServiceImpl implements PostStickerCommandService{
     private final PostStickerRepository postStickerRepository;
     private final PostStickerQueryServiceImpl postStickerQueryService;
     @Override
-    public PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, int xLocation, int yLocation, int width, int height, int angle) {
+    public PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, int xLocation, int yLocation, double scaleX, double scaleY, double rotation) {
         PostSticker newPostSticker = PostSticker.builder()
                 .postId(postId)
                 .stickerId(stickerId)
                 .xLocation(xLocation)
                 .yLocation(yLocation)
-                .width(width)
-                .height(height)
-                .angle(angle)
+                .width(scaleX)
+                .height(scaleY)
+                .angle(rotation)
                 .build();
 
         PostStickerDTO.PostStickerItem savedPostSticker = postStickerQueryService.savePostSticker(newPostSticker);
-        return PostStickerDTO.toPostStickerItem(savedPostSticker.getPostStickerId(), savedPostSticker.getPostId(), savedPostSticker.getStickerId(), savedPostSticker.getXLocation(), savedPostSticker.getYLocation(), savedPostSticker.getWidth(), savedPostSticker.getHeight(), savedPostSticker.getAngle());
+        return PostStickerDTO.toPostStickerItem(savedPostSticker.getPostStickerId(), savedPostSticker.getPostId(), savedPostSticker.getStickerId(), savedPostSticker.getXLocation(), savedPostSticker.getYLocation(), savedPostSticker.getScaleX(), savedPostSticker.getScaleY(), savedPostSticker.getRotation());
     }
 }


### PR DESCRIPTION
## 📌 요약

- 포스트 저장 시에 스티커를 리스트 형태로 받아 서버에 저장함.
- POST service에 사용될 API
- angle -> rotation, width -> scaleX, height -> scaleY 로 변수명 변경됨

## 📝 상세 내용

- **POST** /stickers/post-list
<img width="802" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/51390115/e5ffd011-569b-4f23-b2d3-c9217247e825">

## ☑️ 이슈 번호

- close #365