### PR TITLE
Glue 372 Fix: PostSticker 저장 및 조회 로직 리팩토링

### DIFF
--- a/src/main/java/com/justdo/glue/sticker/domain/basicSticker/BasicSticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/basicSticker/BasicSticker.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
@@ -8,6 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Getter
 @Entity
 public class PostSticker extends BaseTimeEntity {
     @Id
@@ -35,35 +36,4 @@ public class PostSticker extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "DOUBLE")
     private double angle;
 
-    public Long getId() {
-        return id;
-    }
-
-    public Long getPostId() {
-        return postId;
-    }
-
-    public Long getStickerId() {
-        return stickerId;
-    }
-
-    public int getxLocation() {
-        return xLocation;
-    }
-
-    public int getyLocation() {
-        return yLocation;
-    }
-
-    public double getWidth() {
-        return width;
-    }
-
-    public double getHeight() {
-        return height;
-    }
-
-    public double getAngle() {
-        return angle;
-    }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/PostSticker.java
@@ -4,7 +4,7 @@ import com.justdo.glue.sticker.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-@Getter
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -34,4 +34,36 @@ public class PostSticker extends BaseTimeEntity {
 
     @Column(nullable = false, columnDefinition = "DOUBLE")
     private double angle;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getPostId() {
+        return postId;
+    }
+
+    public Long getStickerId() {
+        return stickerId;
+    }
+
+    public int getxLocation() {
+        return xLocation;
+    }
+
+    public int getyLocation() {
+        return yLocation;
+    }
+
+    public double getWidth() {
+        return width;
+    }
+
+    public double getHeight() {
+        return height;
+    }
+
+    public double getAngle() {
+        return angle;
+    }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/controller/PostStickerController.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/controller/PostStickerController.java
@@ -1,6 +1,8 @@
 package com.justdo.glue.sticker.domain.poststicker.controller;
 
 import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.PostStickerItem;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerRequest;
 import com.justdo.glue.sticker.domain.poststicker.service.PostStickerCommandServiceImpl;
 import com.justdo.glue.sticker.domain.poststicker.service.PostStickerQueryServiceImpl;
 import com.justdo.glue.sticker.global.response.ApiResponse;
@@ -8,12 +10,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Post-Sticker API")
 @RestController
@@ -28,48 +32,28 @@ public class PostStickerController {
             "사용자가 포스트를 업로드 할 시 스티커의 정보를 저장합니다.\n" +
                     "업로드 된 포스트 내 스티커의 위치정보, 크기, 각도 정보를 저장하기 위해 사용합니다.")
     @PostMapping("/post")
-    public ApiResponse<PostStickerDTO.PostStickerItem> savePostSticker(@RequestBody PostStickerDTO.PostStickerItem postStickerRequest) {
-        Long postId = postStickerRequest.getPostId();
-        Long stickerId = postStickerRequest.getStickerId();
-        int xLocation = postStickerRequest.getXLocation();
-        int yLocation = postStickerRequest.getYLocation();
-        double scaleX = postStickerRequest.getScaleX();
-        double scaleY = postStickerRequest.getScaleY();
-        double rotation = postStickerRequest.getRotation();
+    public ApiResponse<PostStickerDTO.PostStickerProc> savePostSticker(
+            @RequestBody PostStickerRequest postStickerRequest) {
 
-        return ApiResponse.onSuccess(postStickerCommandService.BuildPostSticker(postId, stickerId, xLocation, yLocation, scaleX, scaleY, rotation));
+        return ApiResponse.onSuccess(postStickerCommandService.savePostSticker(postStickerRequest));
     }
 
     @Operation(summary = "포스트 내 스티커 전체 정보 저장 - Open Feign을 통해 post에서 사용되는 API입니다.", description =
             "사용자가 포스트를 업로드 할 시 스티커의 모든 정보를 저장합니다.\n" +
                     "업로드 된 포스트 내 스티커의 위치정보, 크기, 각도 정보를 저장하기 위해 사용합니다.")
     @PostMapping("/post-list")
-    public ApiResponse<List<PostStickerDTO.PostStickerItem>> savePostStickers(@RequestBody List<PostStickerDTO.PostStickerItem> postStickerRequest) {
+    public void savePostStickers(@RequestBody List<PostStickerRequest> postStickerRequests) {
 
-        List<PostStickerDTO.PostStickerItem> savedItems = postStickerRequest.stream().map(item -> {
-            Long stickerId = item.getStickerId();
-            Long postId = item.getPostId();
-            int xLocation = item.getXLocation();
-            int yLocation = item.getYLocation();
-            double scaleX = item.getScaleX();
-            double scaleY = item.getScaleY();
-            double rotation = item.getRotation();
+        postStickerCommandService.saveAllPostSticker(postStickerRequests);
 
-            return postStickerCommandService.BuildPostSticker(postId, stickerId, xLocation, yLocation, scaleX, scaleY, rotation);
-        }).collect(Collectors.toList());
-
-        return ApiResponse.onSuccess(savedItems);
     }
-
-
 
     @Operation(summary = "포스트 첨부 스티커 이미지 조회 - Open Feign을 통해 post에서 사용되는 API입니다.", description =
             "사용자가 업로드한 포스트의 내부에 첨부된 스티커를 전체 조회합니다.\n" +
                     "포스트 아이디를 입력하면 해당 포스트의 모든 스티커가 표출됩니다.")
     @Parameter(name = "postId", description = "포스트 id, Query Parameter입니다.", required = true, example = "1", in = ParameterIn.QUERY)
     @GetMapping("/poststickers")
-    public PostStickerDTO.PostStickerUrlItems getStickersByPostId(@RequestParam(name="postId") Long postId) {
-        System.out.println(postId);
+    public List<PostStickerItem> getStickersByPostId(@RequestParam(name = "postId") Long postId) {
         return postStickerQueryService.getPostStickersByPostId(postId);
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
@@ -15,7 +15,6 @@ public class PostStickerDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    @Getter
     public static class PostStickerItem {
 
         @Schema(description = "포스트-스티커의 id", example = "1")
@@ -30,12 +29,10 @@ public class PostStickerDTO {
         @Schema(description = "스티커의 url", example = "https://glue-bucket-sticker.s3.ap-northeast-2.amazonaws.com/54728a63-ff4b-4b3e-aea8-18036491b97c.png")
         private String url;
 
-        @Schema(description = "스티커의 x_location", example = "100")
-        @JsonProperty(value = "xlocation")
+        @Schema(description = "스티커의 xLocation", example = "100")
         private int xLocation;
 
-        @Schema(description = "스티커의 y_location", example = "100")
-        @JsonProperty(value = "ylocation")
+        @Schema(description = "스티커의 yLocation", example = "100")
         private int yLocation;
 
         @Schema(description = "스티커의 scaleX", example = "100")
@@ -46,17 +43,52 @@ public class PostStickerDTO {
 
         @Schema(description = "스티커의 rotation", example = "100")
         private double rotation;
+
+        public Long getPostStickerId() {
+            return postStickerId;
+        }
+
+        public Long getPostId() {
+            return postId;
+        }
+
+        public Long getStickerId() {
+            return stickerId;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public int getxLocation() {
+            return xLocation;
+        }
+
+        public int getyLocation() {
+            return yLocation;
+        }
+
+        public double getScaleX() {
+            return scaleX;
+        }
+
+        public double getScaleY() {
+            return scaleY;
+        }
+
+        public double getRotation() {
+            return rotation;
+        }
     }
 
-    public static PostStickerDTO.PostStickerItem toPostStickerItem(PostSticker postSticker,
-            String url) {
+    public static PostStickerDTO.PostStickerItem toPostStickerItem(PostSticker postSticker, String url) {
         return PostStickerItem.builder()
                 .postStickerId(postSticker.getId())
                 .postId(postSticker.getPostId())
                 .stickerId(postSticker.getStickerId())
                 .url(url)
-                .xLocation(postSticker.getXLocation())
-                .yLocation(postSticker.getYLocation())
+                .xLocation(postSticker.getxLocation())
+                .yLocation(postSticker.getyLocation())
                 .scaleX(postSticker.getWidth())
                 .scaleY(postSticker.getHeight())
                 .rotation(postSticker.getAngle())
@@ -78,7 +110,6 @@ public class PostStickerDTO {
     }
 
     public static PostStickerProc toPostStickerProc(Long postStickerId) {
-
         return PostStickerProc.builder()
                 .postStickerId(postStickerId)
                 .createdAt(LocalDateTime.now())

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
@@ -1,5 +1,6 @@
 package com.justdo.glue.sticker.domain.poststicker.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.justdo.glue.sticker.domain.poststicker.PostSticker;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -30,9 +31,11 @@ public class PostStickerDTO {
         private String url;
 
         @Schema(description = "스티커의 x_location", example = "100")
+        @JsonProperty(value = "xlocation")
         private int xLocation;
 
         @Schema(description = "스티커의 y_location", example = "100")
+        @JsonProperty(value = "ylocation")
         private int yLocation;
 
         @Schema(description = "스티커의 scaleX", example = "100")

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
@@ -1,121 +1,85 @@
 package com.justdo.glue.sticker.domain.poststicker.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse;
+import com.justdo.glue.sticker.domain.poststicker.PostSticker;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-
-import java.util.List;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class PostStickerDTO {
-    @Schema(description = "스티커 포스트 정보 DTO")
+
+    @Schema(description = "스티커 포스트 & 스티커 URL 정보 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    @Setter
     public static class PostStickerItem {
 
-        @Schema(description = "포스트-스티커의 id")
-        @JsonProperty("postStickerId")
+        @Schema(description = "포스트-스티커의 id", example = "1")
         private Long postStickerId;
 
-        @Schema(description = "포스트의 id")
-        @JsonProperty("postId")
+        @Schema(description = "포스트의 id", example = "2")
         private Long postId;
 
-        @Schema(description = "스티커의 id")
-        @JsonProperty("stickerId")
+        @Schema(description = "스티커의 id", example = "3")
         private Long stickerId;
 
-        @Schema(description = "스티커의 x_location")
-        @JsonProperty("xLocation")
+        @Schema(description = "스티커의 url", example = "https://glue-bucket-sticker.s3.ap-northeast-2.amazonaws.com/54728a63-ff4b-4b3e-aea8-18036491b97c.png")
+        private String url;
+
+        @Schema(description = "스티커의 x_location", example = "100")
         private int xLocation;
 
-        @Schema(description = "스티커의 y_location")
-        @JsonProperty("yLocation")
+        @Schema(description = "스티커의 y_location", example = "100")
         private int yLocation;
 
-        @Schema(description = "스티커의 scaleX")
-        @JsonProperty("scaleX")
+        @Schema(description = "스티커의 scaleX", example = "100")
         private double scaleX;
 
-        @Schema(description = "스티커의 scaleY")
-        @JsonProperty("scaleY")
+        @Schema(description = "스티커의 scaleY", example = "100")
         private double scaleY;
 
-        @Schema(description = "스티커의 rotation")
-        @JsonProperty("rotation")
+        @Schema(description = "스티커의 rotation", example = "100")
         private double rotation;
     }
 
-    public static PostStickerDTO.PostStickerItem toPostStickerItem(Long postStickerId, Long stickerId, Long postId, int xLocation, int yLocation, double scaleX, double scaleY, double rotation) {
+    public static PostStickerDTO.PostStickerItem toPostStickerItem(PostSticker postSticker,
+            String url) {
         return PostStickerItem.builder()
-                .postStickerId(postStickerId)
-                .postId(postId)
-                .stickerId(stickerId)
-                .xLocation(xLocation)
-                .yLocation(yLocation)
-                .scaleX(scaleX)
-                .scaleY(scaleY)
-                .rotation(rotation)
-                .build();
-    }
-
-    @Schema(description = "포스트에 저장된 스티커 리스트 정보 DTO")
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Getter
-    @Setter
-    public static class PostStickerItems{
-        private List<PostStickerItem> postStickerItems;
-    }
-
-    public static PostStickerDTO.PostStickerItems toPostStickerItems(List<PostStickerItem> postStickerItems){
-        return PostStickerItems.builder()
-                .postStickerItems(postStickerItems)
-                .build();
-    }
-
-    @Schema(description = "url포함 스티커 포스트 정보 DTO")
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Getter
-    @Setter
-    public static class PostStickerUrlItem {
-
-        @Schema(description = "스티커 item")
-        private PostStickerItem postStickerItem;
-
-        @Schema(description = "스티커의 url")
-        private String url;
-    }
-
-    public static PostStickerDTO.PostStickerUrlItem toPostStickerUrlItem(PostStickerItem postStickerItem, String url) {
-        return PostStickerUrlItem.builder()
-                .postStickerItem(postStickerItem)
+                .postStickerId(postSticker.getId())
+                .postId(postSticker.getPostId())
+                .stickerId(postSticker.getStickerId())
                 .url(url)
+                .xLocation(postSticker.getXLocation())
+                .yLocation(postSticker.getYLocation())
+                .scaleX(postSticker.getWidth())
+                .scaleY(postSticker.getHeight())
+                .rotation(postSticker.getAngle())
                 .build();
     }
 
-    @Schema(description = "url 포함 스티커 포스트 정보 DTO")
+    @Schema(description = "포스트 스티커 요청 처리 응답 DTO")
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    @Setter
-    public static class PostStickerUrlItems {
+    public static class PostStickerProc {
 
-        @Schema(description = "url포함 포스트-스티커 리스트")
-        @JsonProperty("postStickerUrlItems")
-        private List<PostStickerUrlItem> postStickerUrlItems;
+        @Schema(description = "포스트 스티커 고유 아이디")
+        private Long postStickerId;
+
+        @Schema(description = "요청 처리 응답 생성 시간")
+        private LocalDateTime createdAt;
     }
 
-    public static PostStickerDTO.PostStickerUrlItems toPostStickerUrlItems(List<PostStickerUrlItem> postStickerUrlItems) {
-        return PostStickerUrlItems.builder()
-                .postStickerUrlItems(postStickerUrlItems)
+    public static PostStickerProc toPostStickerProc(Long postStickerId) {
+
+        return PostStickerProc.builder()
+                .postStickerId(postStickerId)
+                .createdAt(LocalDateTime.now())
                 .build();
     }
+
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerDTO.java
@@ -30,9 +30,11 @@ public class PostStickerDTO {
         private String url;
 
         @Schema(description = "스티커의 xLocation", example = "100")
+        @JsonProperty("xLocation")
         private int xLocation;
 
         @Schema(description = "스티커의 yLocation", example = "100")
+        @JsonProperty("yLocation")
         private int yLocation;
 
         @Schema(description = "스티커의 scaleX", example = "100")
@@ -87,8 +89,8 @@ public class PostStickerDTO {
                 .postId(postSticker.getPostId())
                 .stickerId(postSticker.getStickerId())
                 .url(url)
-                .xLocation(postSticker.getxLocation())
-                .yLocation(postSticker.getyLocation())
+                .xLocation(postSticker.getXLocation())
+                .yLocation(postSticker.getYLocation())
                 .scaleX(postSticker.getWidth())
                 .scaleY(postSticker.getHeight())
                 .rotation(postSticker.getAngle())

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerRequest.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerRequest.java
@@ -3,30 +3,31 @@ package com.justdo.glue.sticker.domain.poststicker.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.justdo.glue.sticker.domain.poststicker.PostSticker;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
 
 public class PostStickerRequest {
 
-    @Schema(description = "포스트의 id")
+    @Schema(description = "포스트의 id", example = "1")
     private Long postId;
 
-    @Schema(description = "스티커의 id")
+    @Schema(description = "스티커의 id", example = "2")
     private Long stickerId;
 
-    @Schema(description = "스티커의 xLocation")
+    @Schema(description = "스티커의 xLocation", example = "100")
+    @JsonProperty("xLocation")
     private int xLocation;
 
-    @Schema(description = "스티커의 yLocation")
+    @Schema(description = "스티커의 yLocation", example = "100")
+    @JsonProperty("yLocation")
     private int yLocation;
 
-    @Schema(description = "스티커의 scaleX")
+    @Schema(description = "스티커의 scaleX", example = "100")
     private double scaleX;
 
-    @Schema(description = "스티커의 scaleY")
+    @Schema(description = "스티커의 scaleY", example = "100")
     private double scaleY;
 
-    @Schema(description = "스티커의 rotation")
+    @Schema(description = "스티커의 rotation", example = "100")
     private double rotation;
 
     public Long getPostId() {

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerRequest.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerRequest.java
@@ -1,0 +1,46 @@
+package com.justdo.glue.sticker.domain.poststicker.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.justdo.glue.sticker.domain.poststicker.PostSticker;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class PostStickerRequest {
+
+    @Schema(description = "포스트의 id")
+    private Long postId;
+
+    @Schema(description = "스티커의 id")
+    private Long stickerId;
+
+    @Schema(description = "스티커의 x_location")
+    @JsonProperty(value = "xlocation")
+    private int xLocation;
+
+    @Schema(description = "스티커의 y_location")
+    @JsonProperty(value = "ylocation")
+    private int yLocation;
+
+    @Schema(description = "스티커의 scaleX")
+    private double scaleX;
+
+    @Schema(description = "스티커의 scaleY")
+    private double scaleY;
+
+    @Schema(description = "스티커의 rotation")
+    private double rotation;
+
+    public static PostSticker toEntity(PostStickerRequest request) {
+
+        return PostSticker.builder()
+                .postId(request.getPostId())
+                .stickerId(request.getStickerId())
+                .xLocation(request.getXLocation())
+                .yLocation(request.getXLocation())
+                .width(request.getScaleX())
+                .height(request.getScaleY())
+                .angle(request.getRotation())
+                .build();
+    }
+}

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerRequest.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/dto/PostStickerRequest.java
@@ -5,7 +5,7 @@ import com.justdo.glue.sticker.domain.poststicker.PostSticker;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
-@Getter
+
 public class PostStickerRequest {
 
     @Schema(description = "포스트의 id")
@@ -14,12 +14,10 @@ public class PostStickerRequest {
     @Schema(description = "스티커의 id")
     private Long stickerId;
 
-    @Schema(description = "스티커의 x_location")
-    @JsonProperty(value = "xlocation")
+    @Schema(description = "스티커의 xLocation")
     private int xLocation;
 
-    @Schema(description = "스티커의 y_location")
-    @JsonProperty(value = "ylocation")
+    @Schema(description = "스티커의 yLocation")
     private int yLocation;
 
     @Schema(description = "스티커의 scaleX")
@@ -31,13 +29,40 @@ public class PostStickerRequest {
     @Schema(description = "스티커의 rotation")
     private double rotation;
 
-    public static PostSticker toEntity(PostStickerRequest request) {
+    public Long getPostId() {
+        return postId;
+    }
 
+    public Long getStickerId() {
+        return stickerId;
+    }
+
+    public int getxLocation() {
+        return xLocation;
+    }
+
+    public int getyLocation() {
+        return yLocation;
+    }
+
+    public double getScaleX() {
+        return scaleX;
+    }
+
+    public double getScaleY() {
+        return scaleY;
+    }
+
+    public double getRotation() {
+        return rotation;
+    }
+
+    public static PostSticker toEntity(PostStickerRequest request) {
         return PostSticker.builder()
                 .postId(request.getPostId())
                 .stickerId(request.getStickerId())
-                .xLocation(request.getXLocation())
-                .yLocation(request.getXLocation())
+                .xLocation(request.getxLocation())
+                .yLocation(request.getyLocation())
                 .width(request.getScaleX())
                 .height(request.getScaleY())
                 .angle(request.getRotation())

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandService.java
@@ -1,7 +1,13 @@
 package com.justdo.glue.sticker.domain.poststicker.service;
 
-import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
+import static com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.*;
+
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerRequest;
+import java.util.List;
 
 public interface PostStickerCommandService {
-    PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, int xLocation, int yLocation, double scaleX, double scaleY, double rotation);
+
+    PostStickerProc savePostSticker(PostStickerRequest postStickerRequest);
+
+    void saveAllPostSticker(List<PostStickerRequest> postStickerRequests);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerCommandServiceImpl.java
@@ -2,7 +2,10 @@ package com.justdo.glue.sticker.domain.poststicker.service;
 
 import com.justdo.glue.sticker.domain.poststicker.PostSticker;
 import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.PostStickerProc;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerRequest;
 import com.justdo.glue.sticker.domain.poststicker.repository.PostStickerRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,22 +13,27 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class PostStickerCommandServiceImpl implements PostStickerCommandService{
-    private final PostStickerRepository postStickerRepository;
-    private final PostStickerQueryServiceImpl postStickerQueryService;
-    @Override
-    public PostStickerDTO.PostStickerItem BuildPostSticker(Long postId, Long stickerId, int xLocation, int yLocation, double scaleX, double scaleY, double rotation) {
-        PostSticker newPostSticker = PostSticker.builder()
-                .postId(postId)
-                .stickerId(stickerId)
-                .xLocation(xLocation)
-                .yLocation(yLocation)
-                .width(scaleX)
-                .height(scaleY)
-                .angle(rotation)
-                .build();
+public class PostStickerCommandServiceImpl implements PostStickerCommandService {
 
-        PostStickerDTO.PostStickerItem savedPostSticker = postStickerQueryService.savePostSticker(newPostSticker);
-        return PostStickerDTO.toPostStickerItem(savedPostSticker.getPostStickerId(), savedPostSticker.getPostId(), savedPostSticker.getStickerId(), savedPostSticker.getXLocation(), savedPostSticker.getYLocation(), savedPostSticker.getScaleX(), savedPostSticker.getScaleY(), savedPostSticker.getRotation());
+    private final PostStickerRepository postStickerRepository;
+
+    @Override
+    public void saveAllPostSticker(List<PostStickerRequest> postStickerRequests) {
+
+        List<PostSticker> postStickers = postStickerRequests.stream()
+                .map(PostStickerRequest::toEntity)
+                .toList();
+
+        postStickerRepository.saveAll(postStickers);
+    }
+
+    @Override
+    public PostStickerProc savePostSticker(PostStickerRequest postStickerRequest) {
+
+        PostSticker newPostSticker = PostStickerRequest.toEntity(postStickerRequest);
+
+        PostSticker save = postStickerRepository.save(newPostSticker);
+
+        return PostStickerDTO.toPostStickerProc(save.getId());
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryService.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryService.java
@@ -1,11 +1,12 @@
 package com.justdo.glue.sticker.domain.poststicker.service;
 
-import com.justdo.glue.sticker.domain.poststicker.PostSticker;
 import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO;
-import org.springframework.data.domain.Page;
+import com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.PostStickerItem;
+import java.util.List;
 
 public interface PostStickerQueryService {
+
     PostStickerDTO.PostStickerItem getPostStickerById(Long id);
-    PostStickerDTO.PostStickerItem savePostSticker(PostSticker postSticker);
-    PostStickerDTO.PostStickerUrlItems getPostStickersByPostId(Long postId);
+
+    List<PostStickerItem> getPostStickersByPostId(Long postId);
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryServiceImpl.java
@@ -36,6 +36,8 @@ public class PostStickerQueryServiceImpl implements PostStickerQueryService {
     @Override
     public List<PostStickerItem> getPostStickersByPostId(Long postId) {
 
+        System.out.println(postId);
+
         Optional<List<PostSticker>> postStickersOptional = postStickerRepository.findByPostId(
                 postId);
 

--- a/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryServiceImpl.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/poststicker/service/PostStickerQueryServiceImpl.java
@@ -1,53 +1,43 @@
 package com.justdo.glue.sticker.domain.poststicker.service;
 
+import static com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.PostStickerItem;
+import static com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.toPostStickerItem;
+import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus._STICKER_POST_NOT_FOUND;
+
 import com.justdo.glue.sticker.domain.poststicker.PostSticker;
-import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.*;
 import com.justdo.glue.sticker.domain.poststicker.repository.PostStickerRepository;
+import com.justdo.glue.sticker.domain.sticker.dto.StickerResponse.StickerItem;
 import com.justdo.glue.sticker.domain.sticker.service.StickerQueryService;
 import com.justdo.glue.sticker.global.exception.ApiException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.justdo.glue.sticker.domain.poststicker.dto.PostStickerDTO.*;
-import static com.justdo.glue.sticker.global.response.code.status.ErrorStatus.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class PostStickerQueryServiceImpl implements PostStickerQueryService{
+public class PostStickerQueryServiceImpl implements PostStickerQueryService {
 
     private final PostStickerRepository postStickerRepository;
     private final StickerQueryService stickerQueryService;
 
     @Override
     public PostStickerItem getPostStickerById(Long id) {
+
         PostSticker postSticker = postStickerRepository.findById(id)
                 .orElseThrow(() -> new ApiException(_STICKER_POST_NOT_FOUND));
 
-        return toPostStickerItem(postSticker.getId(), postSticker.getPostId(), postSticker.getStickerId(), postSticker.getXLocation(), postSticker.getYLocation(), postSticker.getWidth(), postSticker.getHeight(), postSticker.getAngle());
+        return toPostStickerItem(postSticker, null);
     }
 
     @Override
-    @Transactional
-    public PostStickerItem savePostSticker(PostSticker postSticker) {
-        PostSticker savedPostSticker = Optional.of(postStickerRepository.save(postSticker))
-                .orElseThrow(() -> new ApiException(_STICKER_POST_NOT_SAVED));
+    public List<PostStickerItem> getPostStickersByPostId(Long postId) {
 
-        return toPostStickerItem(savedPostSticker.getId(), savedPostSticker.getPostId(), savedPostSticker.getStickerId(), savedPostSticker.getXLocation(), savedPostSticker.getYLocation(), savedPostSticker.getWidth(), savedPostSticker.getHeight(), savedPostSticker.getAngle());
-    }
-
-    @Override
-    public PostStickerUrlItems getPostStickersByPostId(Long postId) {
-        Optional<List<PostSticker>> postStickersOptional = postStickerRepository.findByPostId(postId);
+        Optional<List<PostSticker>> postStickersOptional = postStickerRepository.findByPostId(
+                postId);
 
         if (postStickersOptional.isEmpty()) {
             throw new ApiException(_STICKER_POST_NOT_FOUND);
@@ -55,24 +45,14 @@ public class PostStickerQueryServiceImpl implements PostStickerQueryService{
 
         List<PostSticker> postStickers = postStickersOptional.get(); // Optional에서 리스트를 추출
 
-        List<PostStickerUrlItem> postStickerItems = postStickers.stream()
-                .map(postStickeritem -> {
-                    StickerItem stickerItem = stickerQueryService.getStickerById(postStickeritem.getStickerId());
-                    PostStickerItem postStickerItem = toPostStickerItem(
-                            postStickeritem.getId(),
-                            postStickeritem.getPostId(),
-                            postStickeritem.getStickerId(),
-                            postStickeritem.getXLocation(),
-                            postStickeritem.getYLocation(),
-                            postStickeritem.getWidth(),
-                            postStickeritem.getHeight(),
-                            postStickeritem.getAngle()
+        return postStickers.stream()
+                .map(postSticker -> {
+                    StickerItem stickerItem = stickerQueryService.getStickerById(
+                            postSticker.getStickerId());
+                    return toPostStickerItem(
+                            postSticker, stickerItem.getUrl()
                     );
-                    return toPostStickerUrlItem(postStickerItem, stickerItem.getUrl());
                 })
                 .collect(Collectors.toList());
-
-
-        return toPostStickerUrlItems(postStickerItems);
     }
 }

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/Sticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/Sticker.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/justdo/glue/sticker/domain/sticker/dto/StickerResponse.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/sticker/dto/StickerResponse.java
@@ -36,7 +36,6 @@ public class StickerResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    @Setter
     public static class StickerItem{
         private Long stickerId;
 

--- a/src/main/java/com/justdo/glue/sticker/domain/userSticker/UserSticker.java
+++ b/src/main/java/com/justdo/glue/sticker/domain/userSticker/UserSticker.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder


### PR DESCRIPTION
### 리팩토링한 사항

1. 파라미터로 전달하는 방식을 클래스로 전달하여 처리하였습니다.
2. DTO를 2번 감싸는 클래스를 제거하고 List<DTONAME>으로 구현하였습니다.
3. PostSticker 데이터 정보와 Sticker Url 정보를 따로 보내는 것을 하나의 DTO로 구현하였습니다.

---

### 질문사항

* Swagger에서 조회랑 작성 API 테스트를 해보면 xLocation, yLocation 같은 경우 java, jackson 기본 설정으로 xlocation, ylocation로 스웨거에 표기되는데, Swagger로 테스트 해봤는지 궁금합니다.
> 희찬이가 PR 올린 사진을 보면 xLocation, yLocation으로 조회, 작성을 처리하고 있는거 같아 보여서 물어봅니다. 

<img width="1421" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/103489352/812e29a0-f08a-4c11-94b1-3e6f49005661">

<img width="1420" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/103489352/32bb8962-a246-4e41-afc3-dcb1ff676f3e">


* Postman으로 확인하고 Swagger로는 확인 안했다면, 프론트는 스웨거 보고 연동해야 하니까 (1) 변수명을 수정하거나, (2) @JsonProperty 사용해서 xlocation, ylocation 변수명 매칭해줘야 할 것 같습니다.

<img width="399" alt="image" src="https://github.com/DoTheZ-Team/sticker-service/assets/103489352/bfb23b41-3300-43eb-9d7e-4557352032b3">


### 참고 자료 (꼭 읽어보셈)

https://velog.io/@joshuara7235/변수명-두번째-글자가-대문자-라구요-feat-Lombok-5tufg855

